### PR TITLE
Fix: Resolved 404 Error for Missing Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Once you've sucessfully installed and started the application, you can access th
 
 For the backend replace `<port>` with the specific port number you want to use.
 
-![Alt text](<port env.png>)
+![port env](https://github.com/creative-tutorials/wishme/assets/68476321/814af0e2-b606-406a-863a-d803804e8085)
 
 > [!TIP]  
 > You can hide your `port` if you don't want it to be displayed publicly


### PR DESCRIPTION
This commit tackles an issue where an image was not loading properly, leading to a "404 Not Found" error. The problem was identified and rectified to ensure the image now displays correctly without any errors. The fix involved tracing the source of the error and updating the necessary code to accurately reference and load the image.